### PR TITLE
feat: publish tka via Homebrew tap

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,3 +125,4 @@ jobs:
           args: release --clean --config .goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,7 +29,7 @@ builds:
       - darwin
     goarch: *goarch
     goarm: *goarm
-    binary: ts-k8s-auth
+    binary: tka
     dir: ./cmd/cli/
     mod_timestamp: "{{ .CommitTimestamp }}"
     ldflags: *ldflags
@@ -134,6 +134,28 @@ nfpms:
       - archlinux
     bindir: /usr/bin
 
+homebrew_casks:
+  - name: tka
+    ids:
+      - cli
+    repository:
+      owner: SpechtLabs
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Casks
+    homepage: "https://tka.specht-labs.de"
+    description: "Tailnet-native Kubernetes access with short-lived kubeconfigs."
+    commit_author:
+      name: goreleaser-bot
+      email: bot@specht-labs.de
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/tka"]
+          end
+
 archives:
   - id: server
     ids:
@@ -143,4 +165,4 @@ archives:
   - id: cli
     ids:
       - cli
-    name_template: 'tailscale-k8s-auth_cli_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
+    name_template: 'tka_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'

--- a/README.md
+++ b/README.md
@@ -28,15 +28,14 @@ TKA (Tailscale Kubernetes Auth) is a zero-trust authentication system that issue
 
 ```bash
 # Install TKA CLI
-curl -fsSL https://github.com/spechtlabs/tka/releases/latest/download/ts-k8s-auth-linux-amd64 -o ts-k8s-auth
-chmod +x ts-k8s-auth && sudo mv ts-k8s-auth /usr/local/bin/
+brew install spechtlabs/tap/tka
 
 # Deploy TKA server with Helm
 helm repo add spechtlabs https://charts.specht-labs.de
 helm install tka spechtlabs/tka -n tka-system --create-namespace --set tka.tailscale.tailnet=your-tailnet.ts.net --set secrets.tailscale.authKey=tskey-auth-your-key-here
 
 # Install shell integration for tka wrapper functions
-eval "$(ts-k8s-auth generate integration bash)"  # or zsh/fish
+eval "$(tka generate integration bash)"  # or zsh/fish
 
 # Start an ephemeral session (perfect for debugging)
 tka shell

--- a/cmd/cli/cmd_integration.go
+++ b/cmd/cli/cmd_integration.go
@@ -13,17 +13,17 @@ var cmdIntegration = &cobra.Command{
 	Use:       "integration <bash|zsh|fish|powershell>",
 	Short:     "Generate shell integration for tka wrapper",
 	Example: `# For bash or zsh, add this line to your ~/.bashrc or ~/.zshrc:
-eval "$(ts-k8s-auth shell bash)"
+eval "$(tka generate integration bash)"
 
 # For fish, add this line to your ~/.config/fish/config.fish:
-ts-k8s-auth shell fish | source
+tka generate integration fish | source
 
 # For PowerShell, add this line to your profile (e.g. $PROFILE):
-ts-k8s-auth shell powershell | Out-String | Invoke-Expression
+tka generate integration powershell | Out-String | Invoke-Expression
 `,
-	Long: `The "shell" command generates shell integration code for the tka wrapper.
+	Long: `The "generate integration" command generates shell integration code for the tka wrapper.
 
-By default, the ts-k8s-auth binary cannot directly modify your shell's
+By default, the tka binary cannot directly modify your shell's
 environment variables (such as "${KUBECONFIG}"), because a subprocess cannot
 change the parent shell's state. To work around this, tka provides a
 wrapper function that you can install into your shell. This wrapper
@@ -57,19 +57,19 @@ in your shell for it to take effect.`,
 		switch shell {
 		case "bash":
 			fmt.Println("# Add the following line to your ~/.bashrc:")
-			fmt.Println("#    eval \"$(ts-k8s-auth shell bash)\"")
+			fmt.Println("#    eval \"$(tka generate integration bash)\"")
 			fmt.Println(getBashShell())
 		case "zsh":
 			fmt.Println("# Add the following line to your ~/.zshrc:")
-			fmt.Println("#    eval \"$(ts-k8s-auth shell zsh)\"")
+			fmt.Println("#    eval \"$(tka generate integration zsh)\"")
 			fmt.Println(getZshShell())
 		case "fish":
 			fmt.Println("# Add the following line to your ~/.config/fish/config.fish:")
-			fmt.Println("#   ts-k8s-auth shell fish | source")
+			fmt.Println("#   tka generate integration fish | source")
 			fmt.Println(getFishShell())
 		case "powershell":
 			fmt.Println("# Add the following line to your PowerShell profile:")
-			fmt.Println("#   ts-k8s-auth shell powershell | Out-String | Invoke-Expression")
+			fmt.Println("#   tka generate integration powershell | Out-String | Invoke-Expression")
 			fmt.Println(getPowerShell())
 		default:
 			pretty_print.PrintErrorMessage("Unsupported shell: " + shell)
@@ -95,7 +95,7 @@ func getBashShell() string {
     done
 
     if [[ "$should_eval" == false ]]; then
-        command ts-k8s-auth "$cmd" "$@"
+        command tka "$cmd" "$@"
         return
     fi
 
@@ -111,9 +111,9 @@ func getBashShell() string {
     done
 
     if $no_eval; then
-        command ts-k8s-auth "$cmd" "$@"
+        command tka "$cmd" "$@"
     else
-        eval "$(command ts-k8s-auth "$cmd" --quiet "$@")"
+        eval "$(command tka "$cmd" --quiet "$@")"
     fi
 }
 	`
@@ -125,7 +125,7 @@ func getFishShell() string {
     set disable_flags --no-eval --help --long
 
     if test (count $argv) -eq 0
-        command ts-k8s-auth
+        command tka
         return
     end
 
@@ -147,7 +147,7 @@ func getFishShell() string {
     end
 
     if test "$should_eval" = false
-        command ts-k8s-auth $cmd $args
+        command tka $cmd $args
         return
     end
 
@@ -165,9 +165,9 @@ func getFishShell() string {
     end
 
     if test "$no_eval" = true
-        command ts-k8s-auth $cmd $args
+        command tka $cmd $args
     else
-        eval (command ts-k8s-auth $cmd --quiet $args)
+        eval (command tka $cmd --quiet $args)
     end
 end
 	`
@@ -184,11 +184,12 @@ func getPowerShell() string {
         [string[]]$Args
     )
 
+    $tkaBin = (Get-Command tka -CommandType Application).Source
     $evalCmds = @("login", "refresh")
     $disableFlags = @("--no-eval", "--help", "--long")
 
     if ($Args.Count -eq 0) {
-        & ts-k8s-auth
+        & $tkaBin
         return
     }
 
@@ -205,7 +206,7 @@ func getPowerShell() string {
     }
 
     if (-not $shouldEval) {
-        & ts-k8s-auth @Args
+        & $tkaBin @Args
         return
     }
 
@@ -218,10 +219,10 @@ func getPowerShell() string {
     }
 
     if ($noEval) {
-        & ts-k8s-auth @Args
+        & $tkaBin @Args
     }
     else {
-        $output = & ts-k8s-auth $Args[0] --quiet @($rest)
+        $output = & $tkaBin $Args[0] --quiet @($rest)
         Invoke-Expression $output
     }
 }

--- a/docs/getting-started/comprehensive.md
+++ b/docs/getting-started/comprehensive.md
@@ -48,20 +48,16 @@ This guide covers both development and production deployments with detailed expl
 
 2. ## Step 2: Install TKA CLI
 
-   ### Option A: Download Release (Recommended)
+   ### Option A: Homebrew (Recommended)
 
-   ::: terminal Download and install TKA CLI
+   ::: terminal Install TKA CLI with Homebrew
 
    ```bash
-   # Download CLI for your platform
-   $ curl -fsSL https://github.com/spechtlabs/tka/releases/latest/download/ts-k8s-auth-$(uname)-$(uname -m) -o ts-k8s-auth
-
-   # Make executable and install
-   $ chmod +x ts-k8s-auth
-   $ sudo mv ts-k8s-auth /usr/local/bin/
+   # Install CLI
+   $ brew install spechtlabs/tap/tka
 
    # Test installation
-   $ ts-k8s-auth version
+   $ tka version
    ```
 
    :::
@@ -76,10 +72,10 @@ This guide covers both development and production deployments with detailed expl
    $ cd tka
 
    # Build CLI
-   $ go build -o bin/ts-k8s-auth ./cmd/cli
+   $ go build -o bin/tka ./cmd/cli
 
    # Test build
-   $ ./bin/ts-k8s-auth version
+   $ ./bin/tka version
    ```
 
    :::
@@ -348,7 +344,7 @@ This guide covers both development and production deployments with detailed expl
    EOF
 
    # Install shell integration for the tka wrapper functions
-   $ eval "$(ts-k8s-auth generate integration bash)"  # or zsh/fish
+   $ eval "$(tka generate integration bash)"  # or zsh/fish
    ```
 
    :::
@@ -365,7 +361,7 @@ This guide covers both development and production deployments with detailed expl
    $ export TKA_TAILSCALE_PORT=443
 
    # Still install shell integration for tka wrapper functions
-   $ eval "$(ts-k8s-auth generate integration bash)"  # or zsh/fish
+   $ eval "$(tka generate integration bash)"  # or zsh/fish
    ```
 
    :::

--- a/docs/getting-started/quick.md
+++ b/docs/getting-started/quick.md
@@ -16,9 +16,8 @@ Get TKA running in under 5 minutes:
    ::: terminal One-command setup
 
    ```bash
-   # Download CLI
-   $ curl -fsSL https://github.com/spechtlabs/tka/releases/latest/download/ts-k8s-auth-$(uname)-$(uname -m) -o ts-k8s-auth
-   $ chmod +x ts-k8s-auth && sudo mv ts-k8s-auth /usr/local/bin/
+   # Install CLI
+   $ brew install spechtlabs/tap/tka
 
    # Install server
    $ helm repo add spechtlabs https://charts.specht-labs.de && helm repo update
@@ -68,7 +67,7 @@ Get TKA running in under 5 minutes:
    # Configure CLI
    $ mkdir -p ~/.config/tka
    $ echo "tailscale:\n  hostname: tka\n  tailnet: your-tailnet.ts.net" > ~/.config/tka/config.yaml
-   $ eval "$(ts-k8s-auth generate integration bash)"  # or zsh/fish
+   $ eval "$(tka generate integration bash)"  # or zsh/fish
 
    # Test
    $ kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=tka -n tka-system

--- a/docs/guides/autocompletion.md
+++ b/docs/guides/autocompletion.md
@@ -270,7 +270,7 @@ set -g fish_pager_color_prefix blue
 
 ### Integration with Shell Wrapper
 
-If you're using [shell integration](./shell-integration.md), autocompletion will work seamlessly with the `tka` wrapper function. The completion system understands both the wrapper and the underlying `ts-k8s-auth` binary.
+If you're using [shell integration](./shell-integration.md), autocompletion will work seamlessly with the `tka` wrapper function. The completion system understands both the wrapper and the underlying `tka` binary.
 
 ## Updating Completions
 

--- a/docs/guides/shell-integration.md
+++ b/docs/guides/shell-integration.md
@@ -146,7 +146,7 @@ $ kubectl get pods
 The shell integration is roughly equal to
 
 ```bash
-eval "$(command ts-k8s-auth login --quiet)"
+eval "$(command tka login --quiet)"
 ```
 
 To learn more, I encourage you to checkout the [source code](https://github.com/SpechtLabs/tka/blob/main/cmd/cli/cmd_integration.go#L82) or check out the [Developer Documentation: Shell Integration Details]

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -208,9 +208,9 @@ tka generate integration <bash|zsh|fish|powershell>
 
 #### Description
 
-The "shell" command generates shell integration code for the tka wrapper.
+The "generate integration" command generates shell integration code for the tka wrapper.
 
-By default, the ts-k8s-auth binary cannot directly modify your shell's
+By default, the tka binary cannot directly modify your shell's
 environment variables (such as "${KUBECONFIG}"), because a subprocess cannot
 change the parent shell's state. To work around this, tka provides a
 wrapper function that you can install into your shell. This wrapper
@@ -243,13 +243,13 @@ in your shell for it to take effect.
 
 ```bash
 # For bash or zsh, add this line to your ~/.bashrc or ~/.zshrc:
-eval "$(ts-k8s-auth shell bash)"
+eval "$(tka generate integration bash)"
 
 # For fish, add this line to your ~/.config/fish/config.fish:
-ts-k8s-auth shell fish | source
+tka generate integration fish | source
 
 # For PowerShell, add this line to your profile (e.g. $PROFILE):
-ts-k8s-auth shell powershell | Out-String | Invoke-Expression
+tka generate integration powershell | Out-String | Invoke-Expression
 
 ```
 


### PR DESCRIPTION
## Summary
- publish the CLI artifact as the tka binary instead of ts-k8s-auth
- add a GoReleaser homebrew_casks entry for spechtlabs/tap/tka
- pass HOMEBREW_TAP_GITHUB_TOKEN through the release workflow
- update install and shell integration docs to use brew install spechtlabs/tap/tka and tka generate integration

## Validation
- YAML parse check passed for .goreleaser.yaml and .github/workflows/release.yaml
- gofmt ran on cmd/cli/cmd_integration.go
- stale reference scan passed for ts-k8s-auth, old direct release downloads, and old shell integration examples

## Notes
- goreleaser check was not run locally because goreleaser is not installed.
- go test ./... could not complete locally: after allowing module downloads, the repo still reports missing go.sum entries and the local Go install has a stdlib/tool mismatch: go1.26.1 compiled packages with go1.26.4.